### PR TITLE
Fix game over gui horizontal stretch

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -150,6 +150,9 @@ local function show_endgame_gui(player)
     local winner_style = { font = 'default-bold', font_color = { r = 0.33, g = 0.66, b = 0.9 } }
 
     local main_frame = Gui.add_left_element(player, { type = 'frame', name = 'mvps', direction = 'vertical' })
+    gui_style(main_frame, {
+        horizontally_stretchable = false,
+    })
     local flow = main_frame.add({ type = 'flow', style = 'vertical_flow', direction = 'vertical' })
     local inner_frame = flow.add({ type = 'frame', style = 'inside_shallow_frame_packed', direction = 'vertical' })
 


### PR DESCRIPTION
before:
<img width="785" height="323" alt="before" src="https://github.com/user-attachments/assets/49eb479e-fbfb-4253-a192-4bcf93493cec" />
after:
<img width="785" height="323" alt="after" src="https://github.com/user-attachments/assets/12cbb534-f803-4078-92d7-037e199c1f8f" />


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
